### PR TITLE
3.9.0 release

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,9 +7,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v9
       with:
-        repo-token:  ${{ secrets.FLATHUBBOT_TOKEN }}
+        repo-token: ${{ secrets.FLATHUBBOT_TOKEN }}
         stale-pr-message: "This PR hasn't received any updates in a year and will be automatically closed in 14 days. Feel free to re-open it if you plan to continue working on that pull request or think it deserves attention from Flathub admins"
         days-before-stale: 365
         days-before-close: 14

--- a/io.github.achetagames.epic_asset_manager.json
+++ b/io.github.achetagames.epic_asset_manager.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.achetagames.epic_asset_manager",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "epic_asset_manager",
   "sdk-extensions": [
@@ -15,9 +15,7 @@
     "--filesystem=host",
     "--talk-name=org.freedesktop.secrets",
     "--talk-name=org.freedesktop.Flatpak",
-    "--device=dri",
-    "--env=G_MESSAGES_DEBUG=none",
-    "--env=RUST_LOG=epic_asset_manager=trace"
+    "--device=dri"
   ],
   "build-options": {
     "append-path": "/usr/lib/sdk/rust-stable/bin",
@@ -33,14 +31,20 @@
       "config-opts": [
         "-Dprofile=default"
       ],
+      "cleanup": ["/include", "/lib/pkgconfig", "*.a", "*.la"],
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/AchetaGames/Epic-Asset-Manager/releases/download/v3.8.6/epic_asset_manager-3.8.6.tar.xz",
-          "sha256": "5313d22b742c877f98769284504eb257ea1fedb97f84d44cef9246adc91aa664"
+          "url": "https://github.com/AchetaGames/Epic-Asset-Manager/releases/download/v3.9.2/epic_asset_manager-3.9.2.tar.xz",
+          "sha256": "f3813a64302807e078a5ca230f1ccf660b46b79200ea7aedae5fef23a2e79598",
+          "x-checker-data": {
+            "type": "json",
+            "url": "https://api.github.com/repos/AchetaGames/Epic-Asset-Manager/releases/latest",
+            "version-query": ".tag_name | sub(\"^v\"; \"\")",
+            "url-query": ".assets[] | select(.name==\"epic_asset_manager-\" + $version + \".tar.xz\") | .browser_download_url"
+          }
         }
       ]
     }
   ]
 }
-


### PR DESCRIPTION
## Summary

Update Epic Asset Manager to v3.9.0.

### What's New in v3.9.0

- **FAB Marketplace Integration** — Browse, search, and download Fab marketplace assets directly within the app
- **EULA / Auth Fixes** — Migrated from dead GraphQL endpoint to Cosmos API, fixed 401 errors
- **Download Improvements** — Fixed deadlock on large downloads, added retry limits, progress bar guard
- **GTK4 / Libadwaita Modernization** — Migrated all deprecated widgets to modern equivalents
- **Dependency Updates** — gtk4 0.10, libadwaita 0.8, egs-api 0.14, reqwest 0.13, and more

### Flathub Manifest Changes

- **Runtime**: org.gnome.Platform 46 → 48
- **Removed** `--env=RUST_LOG=epic_asset_manager=trace` (app now uses `EAM_LOG`)
- **Removed** `--env=G_MESSAGES_DEBUG=none` (was a no-op)
- **Added** `cleanup` section to reduce package size
- **Added** `x-checker-data` for automatic update detection via external-data-checker
- **Updated** `actions/stale` from v1 to v9

Full release notes: https://github.com/AchetaGames/Epic-Asset-Manager/releases/tag/v3.9.0